### PR TITLE
Change root to src

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { scanTestOutput } from './testOutputScanner';
 import { guessWorkspaceFolder, itemData, TestCase, TestFile } from './testTree';
 import { BrowserTestRunner, PlatformTestRunner, VSCodeTestRunner } from './vscodeTestRunner';
 
-const TEST_FILE_PATTERN = 'src/vs/**/*.test.ts';
+const TEST_FILE_PATTERN = 'src/**/*.test.ts';
 
 const getWorkspaceFolderForTestFile = (uri: vscode.Uri) =>
   uri.path.endsWith('.test.ts') ? vscode.workspace.getWorkspaceFolder(uri) : undefined;

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -61,7 +61,7 @@ export class TestFile {
   }
 
   public getLabel() {
-    return relative(join(this.workspaceFolder.uri.fsPath, 'src', 'vs'), this.uri.fsPath);
+    return relative(join(this.workspaceFolder.uri.fsPath, 'src'), this.uri.fsPath);
   }
 
   public async updateFromDisk(controller: vscode.TestController, item: vscode.TestItem) {


### PR DESCRIPTION
I'm from the Azure Data Studio team (which itself is a product that's a fork of VS Code). We'd love to use this extension ourselves but currently it's set up just to pull things from the vs folder under src, where as we have things under our own [sql](https://github.com/microsoft/azuredatastudio/tree/main/src/sql) folder.

One option of course is to fork this extension and make the changes ourselves, but if you were willing to take these small changes that'd help reduce that extra overhead. 

The test file pattern shouldn't result in there being any differences for VS Code - aside from slightly longer time to search the folders under src. 

The label change does mean that tests will show up prefixed with `vs` for VS Code - e.g. 

![image](https://user-images.githubusercontent.com/28519865/131922683-0f75e458-d009-45fc-bc31-f48858bb4223.png)

If that's something you'd rather not have (since it's essentially pointless for VS Code to display that currently) then I can look at other options, but figured I'd start with the simplest "fix" that I could. 