### PR TITLE
feat: implement basic related code support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "displayName": "VS Code Selfhost Test Provider",
   "description": "Test provider for the VS Code project",
   "enabledApiProposals": [
-    "testObserver"
+    "testObserver",
+    "testRelatedCode"
   ],
   "version": "0.3.9",
   "publisher": "ms-vscode",

--- a/src/relatedCode.ts
+++ b/src/relatedCode.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { getContentFromFilesystem, itemData, TestFile } from './testTree';
+
+type ChildIterator = { forEach(fn: (t: vscode.TestItem) => void): void };
+
+/**
+ * Updates the "related code" of tests in the file.
+ */
+export const updatedRelatedCodeForTestFile = async (file: TestFile, testItems: ChildIterator) => {
+  if (!file.relatedCodeFile) {
+    return;
+  }
+
+  const content = await getContentFromFilesystem(file.relatedCodeFile);
+  if (!content) {
+    return;
+  }
+
+  return updatedRelatedCodeFromContents(file.relatedCodeFile, testItems, content);
+};
+
+/**
+ * Updates the "related code" of tests that have implementations in
+ * the file. Assumes the tests are already discovered, doesn't
+ * eagerly do discovery.
+ */
+export const updateRelatedCodeForImplementation = async (
+  file: vscode.Uri,
+  children: vscode.TestItemCollection,
+  contents: string
+) => {
+  children.forEach(child => {
+    const item = itemData.get(child);
+    if (item instanceof TestFile && item.relatedCodeFile?.path === file.path) {
+      updatedRelatedCodeFromContents(file, child.children, contents);
+    }
+  });
+};
+
+const isDocCommentLike = /^\s* \* /;
+
+/**
+ * Updates related code in each TestItem from the contents of the
+ * implementation code. Assumes that each test involves testing a
+ * method, function, or class and is labeled correspondingly. This
+ * may not hold true for all tests, but is true for some tests.
+ */
+const updatedRelatedCodeFromContents = (
+  uri: vscode.Uri,
+  testItems: ChildIterator,
+  relatedCodeFileContents: string
+) => {
+  const lines = relatedCodeFileContents.split(/\r?\n/g);
+  const addRelatedCode = (testItem: vscode.TestItem) => {
+    let found = false;
+    for (let line = 0; line < lines.length; line++) {
+      const contents = lines[line];
+      if (contents.startsWith('//') || isDocCommentLike.test(contents)) {
+        continue;
+      }
+
+      const index = contents.indexOf(testItem.label);
+      if (index === -1) {
+        continue;
+      }
+
+      testItem.relatedCode = [
+        new vscode.Location(
+          uri,
+          new vscode.Range(
+            new vscode.Position(line, index),
+            new vscode.Position(line, index + testItem.label.length)
+          )
+        ),
+      ];
+      found = true;
+      break;
+    }
+
+    if (!found) {
+      testItem.relatedCode = undefined;
+    }
+
+    testItem.children.forEach(addRelatedCode);
+  };
+  testItems.forEach(addRelatedCode);
+};

--- a/src/sourceUtils.ts
+++ b/src/sourceUtils.ts
@@ -13,7 +13,19 @@ export const enum Action {
   Recurse,
 }
 
+export class ImportDeclaration {
+  public get basename() {
+    return this.text.split('/').pop()!;
+  }
+
+  constructor(public readonly text: string) {}
+}
+
 export const extractTestFromNode = (src: ts.SourceFile, node: ts.Node, parent: VSCodeTest) => {
+  if (ts.isImportDeclaration(node) && ts.isStringLiteralLike(node.moduleSpecifier)) {
+    return new ImportDeclaration(node.moduleSpecifier.text);
+  }
+
   if (!ts.isCallExpression(node)) {
     return Action.Recurse;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "target": "ES2019",
+    "target": "ES2020",
     "outDir": "out",
-    "lib": ["ES2019"],
+    "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
     "moduleResolution": "node",


### PR DESCRIPTION
This implements basic "related code" support. It's pretty simple -- for any test file, if it imports a file of a similar name, then look for the test labels in that file. If they exist, mark them as related code. This works decently well for tests that directly reference methods of classes.