### PR TITLE
fix: wait for initialized more correctly

### DIFF
--- a/src/vscodeTestRunner.ts
+++ b/src/vscodeTestRunner.ts
@@ -63,23 +63,21 @@ export abstract class VSCodeTestRunner {
           return;
         }
 
-        let breakpointRequestId: number | undefined;
+        let initRequestId: number | undefined;
 
         return {
           onDidSendMessage(message) {
-            if (message.type === 'response' && message.request_seq === breakpointRequestId) {
+            if (message.type === 'response' && message.request_seq === initRequestId) {
               server.ready();
             }
           },
           onWillReceiveMessage(message) {
-            if (breakpointRequestId !== undefined) {
+            if (initRequestId !== undefined) {
               return;
             }
 
-            if (message.command === 'configurationDone') {
-              server.ready();
-            } else if (message.command === 'setBreakpoints') {
-              breakpointRequestId = message.seq;
+            if (message.command === 'launch' || message.command === 'attach') {
+              initRequestId = message.seq;
             }
           },
         };


### PR DESCRIPTION
js-debug will wait until all breakpoints are set up before responding to the launch/attach request. So just use the reply to signal the start of debugging.