### PR TITLE
fix: show diff if actual/expected output is an empty string

### DIFF
--- a/src/testOutputScanner.ts
+++ b/src/testOutputScanner.ts
@@ -222,8 +222,9 @@ export async function scanTestOutput(
               }
 
               tests.delete(id);
+
               const hasDiff =
-                actual && expected && (expected !== '[undefined]' || actual !== '[undefined]');
+                (actual !== undefined) && (expected !== undefined) && (expected !== '[undefined]' || actual !== '[undefined]');
               const testFirstLine =
                 tcase.range &&
                 new vscode.Location(


### PR DESCRIPTION
Currently, if the actual/expected output is an empty string [1], there's an error message instead of a diff: 

<img width="941" alt="image" src="https://user-images.githubusercontent.com/16353531/217564212-5cbe8374-8dc1-48d8-9928-4fd6c86ffee5.png">

With this PR, we get a pretty diff: 

 
<img width="912" alt="image" src="https://user-images.githubusercontent.com/16353531/217564537-8b59320a-071c-4cf1-8d97-2441253a420b.png">


[1] happens when, for example, the dev doesn't want to write the expected output themselves but wants to copy-paste the actual output as expected after the first run